### PR TITLE
Fix tutorial links

### DIFF
--- a/templates/tutorials.html
+++ b/templates/tutorials.html
@@ -25,19 +25,7 @@
 
     <div class="col-4 p-card--featured">
       <div>
-        <h3 class="p-heading--4"><a href="https://ubuntu.com/tutorials/wayland-kiosk#1-overview">How to create graphical snaps for IoT devices on top of a Wayland stack</a></h3>
-        <p>
-          A guide on how to create graphical snaps for Ubuntu with a single GUI application running fullscreen on the display.
-
-        </p>
-      </div>
-      <footer class="p-card__footer">
-        Difficulty: <span class="p-tutorials-meter p-tutorials-meter--3">3 out of 5</span>
-      </footer>
-    </div>
-    <div class="col-4 p-card--featured">
-      <div>
-        <h3 class="p-heading--4"><a href="https://tutorials.ubuntu.com/tutorial/graphical-snaps-xwayland#0">How to create graphical snaps for IoT devices on top of an Xwayland stack</a></h3>
+        <h3 class="p-heading--4"><a href="/docs/packaging-an-x11-application-as-an-iot-gui">How to create graphical snaps for IoT devices on top of an Xwayland stack</a></h3>
         <p>
           A guide on how to create graphical snaps for Ubuntu with a single GUI application running fullscreen on the display.
         </p>
@@ -46,13 +34,10 @@
         Difficulty: <span class="p-tutorials-meter p-tutorials-meter--4">4 out of 5</span>
       </footer>
     </div>
-  </div>
 
-
-  <div class="row u-equal-height">
     <div class="col-4 p-card--featured">
       <div>
-        <h3 class="p-heading--4"><a href="https://discourse.ubuntu.com/t/howto-run-your-kiosk-snap-on-your-desktop/11180">How to run your kiosk snap on your desktop</a></h3>
+        <h3 class="p-heading--4"><a href="/docs/howto-run-your-iot-gui-on-your-desktop">How to run your kiosk snap on your desktop</a></h3>
         <p>
           A guide for developers to develop their Mir-kiosk applications working on Ubuntu desktop. Learn how to simply have Mir-kiosk running on a window on your desktop, before going to your device.
         </p>
@@ -61,6 +46,10 @@
         Difficulty: <span class="p-tutorials-meter p-tutorials-meter--2">2 out of 5</span>
       </footer>
     </div>
+  </div>
+
+
+  <div class="row u-equal-height">
     <div class="col-4 p-card--featured">
       <div>
         <h3 class="p-heading--4"><a href="https://forum.snapcraft.io/t/debugging-graphical-apps-on-ubuntu-core/23671">Debugging Graphical Apps on Ubuntu Core</a></h3>
@@ -74,7 +63,7 @@
     </div>
     <div class="col-4 p-card--featured">
       <div>
-        <h3 class="p-heading--4"><a href="https://tutorials.ubuntu.com/tutorial/graphical-snaps#0">How to build a digital signage app for embedded displays</a></h3>
+        <h3 class="p-heading--4"><a href="/docs/make-a-secure-ubuntu-web-kiosk">How to build a digital signage app for embedded displays</a></h3>
         <p>
           A guide to creating graphical snaps for Ubuntu IoT devices on top of an Xwayland stack. Learn how to build a digital signage app for kiosks, advertising screens and other embedded displays.
         </p>


### PR DESCRIPTION
## Done

Fix tutorial links

## QA

Check that https://mir-server-io-195.demos.haus/tutorials is redirecting to the right tutorials.

