### PR TITLE
[copy update] WD-6029 - Add SDL logo

### DIFF
--- a/templates/ubuntu-frame.html
+++ b/templates/ubuntu-frame.html
@@ -63,6 +63,9 @@
           <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/82c52642-microsoft-azure.svg" alt="Microsoft Azure">
         </div>
         <div class="p-logo-section__item">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/086b3df5-sdl-logo.svg" alt="Simple Directmedia Layer">
+        </div>
+        <div class="p-logo-section__item">
           <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/f0cf1fa3-google-cloud-logo.svg" alt="Google Cloud Platform">
         </div>
       </div>


### PR DESCRIPTION
## Done

- Add SDL logo to the logo section on `/ubuntu-frame`

## QA

- Check out [the demo here](https://mir-server-io-232.demos.haus/ubuntu-frame) and make sure the SDL logo attached to [the task](https://warthogs.atlassian.net/browse/WD-6029) has been added to the logo section on the page.

## Issue / Card

- [WD-6029](https://warthogs.atlassian.net/browse/WD-6029)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-6029]: https://warthogs.atlassian.net/browse/WD-6029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ