### PR TITLE
Update canonicalwebteam.discourse to 5.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.4.3
+canonicalwebteam.discourse==5.5.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
 vcrpy-unittest==0.1.7


### PR DESCRIPTION
## Done

Update canonicalwebteam.discourse to 5.5.0

## QA

- Go to https://mir-server-io-249.demos.haus/docs
- Inspect a heading (h2 and down) and see the anchor link within it doesn't have trailing number