### PR TITLE
WD-12936 Upgraded Versions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@canonical/global-nav": "3.5.0",
     "@canonical/cookie-policy": "3.5.0",
-    "vanilla-framework": "4.5.0"
+    "vanilla-framework": "4.14.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.13",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
 vcrpy-unittest==0.1.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.5.0.tgz#992332239682821094defaae0e8aacd343bf9239"
-  integrity sha512-35q360QpJirosK7403fSQLRPXsdabZ6LdkP2x5bqJBak3rkwmYE34wOqGbm0KggQLXSZimW5ZP2Y+0LohtAF+w==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
# Done
- Upgraded versions of  discourse to 5.6.0 and vanilla to 4.14.0 as it is required by discourse.

# QA
- Run the site using dotrun command.
- See if everything on site is working as it should
- Notice for any abnormalities that could be due to change in package versions.
## Fixes [WD-12936](https://warthogs.atlassian.net/browse/WD-12936)



[WD-12936]: https://warthogs.atlassian.net/browse/WD-12936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ