### PR TITLE
WD-12936 - update canonicalwebteam.discourse to 5.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.discourse==5.6.0
+canonicalwebteam.discourse==5.6.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
 vcrpy-unittest==0.1.7


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.1

## QA

- Check that the changes in vanilla have not broken anything

## Issue / Card
[WD-12936](https://warthogs.atlassian.net/browse/WD-12936)