### PR TITLE
WD-13370 Bumped cookie-policy to v3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "3.5.0",
-    "@canonical/cookie-policy": "3.5.0",
+    "@canonical/cookie-policy": "3.6.4",
     "vanilla-framework": "4.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Done
Bumped cookie-policy to v3.6.4
# QA
- Delete cookies so you get the cookie policy pop up
- Accept nothing and check that in cookies there exists `_cookies_accepted=essential`
- Repeat with only accept 'performance', only accepting 'functional' and finally 'all'
# Fixes
 [WD-13370](https://warthogs.atlassian.net/browse/WD-13370)