### PR TITLE
Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@canonical/global-nav": "3.5.0",
     "@canonical/cookie-policy": "3.6.4",
-    "vanilla-framework": "4.14.0"
+    "vanilla-framework": "4.16.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.13",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.0
 canonicalwebteam.image-template==1.3.1
 vcrpy-unittest==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==2.1.0
+canonicalwebteam.search==2.1.1
 canonicalwebteam.image-template==1.3.1
 vcrpy-unittest==0.1.7

--- a/templates/ubuntu-frame.html
+++ b/templates/ubuntu-frame.html
@@ -11,7 +11,7 @@
       <h1>Simplify the development of embedded displays</h1>
       <p>Ubuntu Frame is a reliable and secure display server for embedded Linux devices with long term support. Simple to configure, simple to deploy.</p>
       <p><a href="https://assets.ubuntu.com/v1/713b9224-Ubuntu.Frame.Datasheet.pdf" class="p-button--positive">Get the Ubuntu Frame datasheet</a></p>
-      <p><a class="p-link--inverted" href="https://ubuntu.com/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Learn how to develop GUIs for IoT with our developer guide&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--inverted is-dark" href="https://ubuntu.com/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Learn how to develop GUIs for IoT with our developer guide&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -70,7 +70,6 @@ app.add_url_rule(
         session=session,
         site="mir-server.io",
         template_path="docs/search.html",
-        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -66,9 +66,11 @@ app.add_url_rule(
     "/docs/search",
     "docs-search",
     build_search_view(
+        app=app,
         session=session,
         site="mir-server.io",
         template_path="docs/search.html",
+        request_limit="1/day",
     ),
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ vanilla-framework@4.0.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.0.0.tgz#a2fee9bd9763ebd6932b764f9d66484dc177d4cc"
   integrity sha512-fiPnmaTUe15l5MRNJ6IsiJ8qiunfmgtLETOFltaYiE/bQKL7xTI+riBak2iygBKeF1y0Gi/GxUNt4hyb6xDPKA==
 
-vanilla-framework@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
-  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+vanilla-framework@4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
+  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Upgrade canonicalwebteam.search to 2.1.1
- This had a dependency on canonicalwebteam.flask-base, so I upgraded that to 2.0.0

**Fly-by:**
- Upgrade Vanilla to 4.16.0
- Add `is-dark` styling to link on /ubuntu-frame

## QA

- Go to https://mir-server-io-256.demos.haus/docs/search
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)

- Go to /ubuntu-frame and see the link in the hero is white

## Fixes

Issue: https://warthogs.atlassian.net/browse/WD-15012

## Screenshots

![image](https://github.com/user-attachments/assets/044accb6-2af2-44ac-b5c0-9a2cadb902a3)
